### PR TITLE
'EchoTime' in JSON needs to be a number to be bids compatable

### DIFF
--- a/bidscoin/echocombine.py
+++ b/bidscoin/echocombine.py
@@ -95,7 +95,7 @@ def echocombine(bidsdir: str, pattern: str, subjects: list, output: str, algorit
                 shutil.copyfile(echos[0].with_suffix('').with_suffix('.json'), mejson)
                 with mejson.open('r') as fmap_fid:
                     data = json.load(fmap_fid)
-                data['EchoTime']   = 'n/a'
+                data.pop('EchoTime')
                 data['EchoNumber'] = 1
                 with mejson.open('w') as fmap_fid:
                     json.dump(data, fmap_fid, indent=4)


### PR DESCRIPTION
I updated the line in witch 'EchoTime' is set to 'n/a' to data.pop('EchoTime'). I am not sure the .pop works like this? 