### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ python-dateutil
 nibabel
 pydeface
 drmaa
-importlib
 # dcm2niix. For more information, see ./docs/installation.md and ./heuristics/bidsmap_template.yaml


### PR DESCRIPTION
I'm pretty sure `importlib` was mistakingly added to `requirements.txt`. Whatever the reason was, it prevents `bidscoin` from being installed via pip (`ModuleNotFoundError: No module named 'importlib.util'`, tested with Python 3.8+). Removing the `importlib` dependency fixes the issue for me and as `importlib` is part of the Python Standard Library from v3.1 onwards, I don't think there is any need in including it anyways (which is probably the cause of the error).