### PR TITLE
Simplified the singularity definition.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -127,7 +127,7 @@ To install the latest develop realease of BIDScoin, substitute
 
 .. code-block:: console
 
-   pip3 install bidscoin --no-deps
+   pip3 install bidscoin
 
 with
 
@@ -140,7 +140,7 @@ in the definition ``singularity.def`` file.
 Speed up building the image
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To speed up building the Singularity image, you can change the ``apt`` servers to download the packages from a location closer to you. Add the following line as the first command in the ``%post`` section of  ``singularity.def`` file.
+To speed up building the Singularity image, you can change the ``apt`` servers to download the packages from a location closer to you. For example, add the following line as the first command in the ``%post`` section of  ``singularity.def`` file to download the packages from Austria (`at`).
 
 .. code-block:: console
 

--- a/singularity.def
+++ b/singularity.def
@@ -15,17 +15,8 @@ OSVersion: stable
     make install
 
     # Install BIDScoin from Python repository.
-    # Install as much as possible as Debian package.
-    # NOTE: There were dependency issues. It helped to install PyQt5 from Debian package. 
+    # NOTE: PyQt5 is installed as Debian package to solve dependencies issues occurring when installed with pip.
     apt-get -y install \
-        python3-pandas \
-        python3-matplotlib \
-        python3-numpy \
-        python3-pyqt5 \
-        python3-ruamel.yaml \
-        python3-coloredlogs \
-        python3-dateutil \
-        python3-nibabel \
-        python3-pip
-    pip3 install multiecho pydeface drmaa pydicom --upgrade
-    pip3 install bidscoin --no-deps # Install the latest stable release.
+        python3-pip \
+        python3-pyqt5
+    pip3 install bidscoin # Install the latest stable release.


### PR DESCRIPTION
I simplified the definition file and did minor changes in the documentation.

The current definition file is for BIDScoin without extra plugins. Shall we do something about it? I'm not using other plugins. I can help but it would be great to have some tests. And about that, `bidscoin -t` is in the documentation but not implemented.