### PR TITLE
Catch possible ValueError if run is not specified by user

### DIFF
--- a/bidscoin/bidscoiner.py
+++ b/bidscoin/bidscoiner.py
@@ -268,8 +268,8 @@ def addmetadata(bidsses: Path, subid: str, sesid: str) -> None:
 
             # Check if there are multiple runs and get the lower- and upperbound from the AcquisitionTime
             runindex   = bids.get_bidsvalue(fmap, 'run')
-            prevfmap   = bids.get_bidsvalue(fmap, 'run', str(int(runindex) - 1))
-            nextfmap   = bids.get_bidsvalue(fmap, 'run', str(int(runindex) + 1))
+            prevfmap   = bids.get_bidsvalue(fmap, 'run', str(int(runindex) - 1 if runindex else ''))
+            nextfmap   = bids.get_bidsvalue(fmap, 'run', str(int(runindex) + 1 if runindex else ''))
             acqtime    = scans_table.loc[fmap, 'acq_time']
             fmaptime   = dateutil.parser.parse(acqtime if isinstance(acqtime,str) else '1925-01-01')
             lowerbound = fmaptime.replace(hour=0,  minute=0,  second=0)


### PR DESCRIPTION
Hey there!

I found this ValueError while running v 3.7.3, but I'm not sure it's fixed in v 3.7.4 - unless when users don't specify a run in the bidsmap.yaml, the run value is automatically provided as `NaN` or `0`.

Don't know if it helps, but I hope so!