### PR TITLE
Declare minimum tqdm version required for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pydicom>=2
 PyQt5>=5.12.1
 ruamel.yaml>=0.15.35
 coloredlogs
-tqdm
+tqdm>=4.60.0
 multiecho>=0.25
 python-dateutil
 nibabel


### PR DESCRIPTION
`tqdm.contrib.logging` submodule was introduced only in [version 4.60.0](https://github.com/tqdm/tqdm/releases/tag/v4.60.0)