### PR TITLE
FIX: add dcm2niix build options for jpeg2000 support in singularity definition.

### DIFF
--- a/singularity.def
+++ b/singularity.def
@@ -11,7 +11,7 @@ OSVersion: stable
     git clone https://github.com/rordenlab/dcm2niix.git
     cd dcm2niix
     mkdir build && cd build
-    cmake ..
+    cmake -DZLIB_IMPLEMENTATION=Cloudflare -DUSE_JPEGLS=ON -DUSE_OPENJPEG=ON ..
     make install
 
     # Install curl (sometimes needed by dcm2niix)


### PR DESCRIPTION
This fixes the error `unsupported transfer syntax` of `dcm2niix`.

See https://neurostars.org/t/unsupported-transfer-syntex-when-using-dcm2niix/6089/2.