### PR TITLE
Fix dynamic <<>> runindex

### DIFF
--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -1389,7 +1389,7 @@ def get_run(bidsmap: dict, datatype: str, suffix_idx: Union[int, str], datasourc
         if index == suffix_idx or run['bids']['suffix'] == suffix_idx:
 
             # Get a clean run (remove comments to avoid overly complicated commentedMaps from ruamel.yaml)
-            run_ = create_run(datasource, bidsmap)
+            run_ = create_run(copy.deepcopy(datasource), bidsmap)
             run_['datasource'].datatype = datatype
 
             for propkey, propvalue in run['properties'].items():

--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -1989,7 +1989,8 @@ def rename_runless_to_run1(runs: List[dict], scans_table: pd.DataFrame) -> None:
                     run['datasource'].targets.remove(target)
                     run['datasource'].targets.append((outfolder/run1_bidsname).with_suffix(suffixes))
 
-def updatemetadata(sourcemeta: Path, targetmeta: Path, usermeta: dict, extensions: list, datasource: DataSource) -> dict:
+
+def updatemetadata(datasource: DataSource, targetmeta: Path, usermeta: dict, extensions: list, sourcemeta: Path = Path()) -> dict:
     """
     Load the metadata from the target (json sidecar), then add metadata from the source (json sidecar) and finally add
     the user metadata (meta table). Source metadata other than json sidecars are copied over to the target folder. Special
@@ -1997,15 +1998,17 @@ def updatemetadata(sourcemeta: Path, targetmeta: Path, usermeta: dict, extension
 
     NB: In future versions this function could also support more source metadata formats, e.g. yaml, csv- or Excel-files
 
-    :param sourcemeta:  The filepath of the source data file with associated/equally named meta-data files (name may include wildcards)
+    :param datasource:  The data source from which dynamic values are read
     :param targetmeta:  The filepath of the target data file with meta-data
     :param usermeta:    A user metadata dict, e.g. the meta table from a run-item
     :param extensions:  A list of file extensions of the source metadata files, e.g. as specified in bidsmap['Options']['plugins']['plugin']['meta']
-    :param datasource:  The data source from which dynamic values are read
+    :param sourcemeta:  The filepath of the source data file with associated/equally named meta-data files (name may include wildcards). Leave empty to use datasource.path
     :return:            The combined target + source + user metadata
     """
 
     metapool = {}
+    if not sourcemeta.name:
+        sourcemeta = datasource.path
 
     # Add the target metadata to the metadict
     if targetmeta.is_file():

--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -2213,6 +2213,7 @@ def add_bids_mappings(bids_mappings: List[BidsMapping], session: Path, bidsfolde
 
     # save bids mappings
     out.parent.mkdir(parents=True, exist_ok=True)
+    LOGGER.verbose(f"Writing bids mappings data to: {out}")
     df_combined.to_csv(out, sep='\t', index=False)
 
 

--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -20,7 +20,7 @@ import pandas as pd
 import ast
 from functools import lru_cache
 from pathlib import Path
-from typing import Union, List, Tuple
+from typing import Dict, List, Set, Tuple, Union
 from nibabel.parrec import parse_PAR_header
 from pandas import DataFrame
 from pydicom import dcmread, fileset, datadict
@@ -311,6 +311,32 @@ class DataSource:
                 value = sanitize(value)
 
         return value
+
+
+class BidsMapping:
+    """
+    Represents a mapping of BIDS target files from source data.
+    :param source:      Path to source data
+    :param targets:     BIDS target files converted from source data
+    :param datatype:    The BIDS data type of the data source and targets
+    :param run:         Bidsmap run used for conversion
+    """
+    def __init__(self, source: Path, targets: Set[Path], datatype: str, run: Dict):
+        """
+        Initialize BidsMapping.
+        :param source:      Path to source data
+        :param targets:     BIDS target files converted from source data
+        :param datatype:    The BIDS data type of the data source and targets
+        :param run:         Bidsmap run used for conversion
+        """
+        self.source = source
+        self.targets = targets
+        self.datatype = datatype
+        self.run = run
+
+    def __repr__(self):
+        return (f"BidsMapping(source={self.source!r}, targets={self.targets!r}, "
+                f"datatype={self.datatype!r})")
 
 
 def unpack(sourcefolder: Path, wildcard: str='', workfolder: Path='') -> Tuple[List[Path], bool]:

--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -20,9 +20,8 @@ import pandas as pd
 import ast
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, List, Set, Tuple, Union
+from typing import List, Set, Tuple, Union
 from nibabel.parrec import parse_PAR_header
-from pandas import DataFrame
 from pydicom import dcmread, fileset, datadict
 from importlib.util import find_spec
 if find_spec('bidscoin') is None:
@@ -53,7 +52,7 @@ with (schemafolder/'objects'/'metadata.yaml').open('r') as _stream:
 
 
 class DataSource:
-    def __init__(self, provenance: Union[str, Path]='', plugins: dict=None, dataformat: str='', datatype: str='', subprefix: str='', sesprefix: str='', targets: set[Path] = ()):
+    def __init__(self, provenance: Union[str, Path]='', plugins: dict=None, dataformat: str='', datatype: str='', subprefix: str='', sesprefix: str='', targets: Set[Path] = ()):
         """
         A source data type (e.g. DICOM or PAR) that can be converted to BIDS by the plugins
 

--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -2196,12 +2196,16 @@ def add_bids_mappings(bids_mappings: List[BidsMapping], session: Path, bidsfolde
             else:
                 target_subject = bidsses.name
                 target_session = None
+            if target.relative_to(bidsfolder).parts[0] == "derivatives":
+                target_outfolder = bidsfolder
+            else:
+                target_outfolder = bidsses
             new_entry = {
                 "subject": target_subject,
                 "session": target_session,
                 'SeriesDescription': bids_mapping.run.get("attributes", {}).get("SeriesDescription"),
                 'source': bids_mapping.source.relative_to(session.parent),
-                'BIDS_mapping': target.relative_to(bidsses),
+                'BIDS_mapping': target.relative_to(target_outfolder),
             }
             entries.append(new_entry)
     df_mappings = pd.DataFrame(entries)

--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -53,7 +53,7 @@ with (schemafolder/'objects'/'metadata.yaml').open('r') as _stream:
 
 
 class DataSource:
-    def __init__(self, provenance: Union[str, Path]='', plugins: dict=None, dataformat: str='', datatype: str='', subprefix: str='', sesprefix: str='', targets: List[Path] = ()):
+    def __init__(self, provenance: Union[str, Path]='', plugins: dict=None, dataformat: str='', datatype: str='', subprefix: str='', sesprefix: str='', targets: set[Path] = ()):
         """
         A source data type (e.g. DICOM or PAR) that can be converted to BIDS by the plugins
 
@@ -76,7 +76,7 @@ class DataSource:
             self.is_datasource()
         self.subprefix   = subprefix
         self.sesprefix   = sesprefix
-        self.targets     = list(targets)
+        self.targets     = set(targets)
         self._cache      = {}
 
     def resubprefix(self) -> str:
@@ -1987,7 +1987,7 @@ def rename_runless_to_run1(runs: List[dict], scans_table: pd.DataFrame) -> None:
 
                     # Change target from run-less to run-1
                     run['datasource'].targets.remove(target)
-                    run['datasource'].targets.append((outfolder/run1_bidsname).with_suffix(suffixes))
+                    run['datasource'].targets.add((outfolder/run1_bidsname).with_suffix(suffixes))
 
 
 def updatemetadata(datasource: DataSource, targetmeta: Path, usermeta: dict, extensions: list, sourcemeta: Path = Path()) -> dict:

--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -2212,6 +2212,18 @@ def add_bids_mappings(bids_mappings: List[BidsMapping], session: Path, bidsfolde
     df_combined.to_csv(out, sep='\t', index=False)
 
 
+def drop_session_from_bids_mappings(bids_mappings_file: Path) -> None:
+    """
+    Drops session column from bids_mappings.tsv if no session.
+    :param bids_mappings_file:   Path to bids_mappings.tsv
+    """
+    if bids_mappings_file.exists():
+        df_mappings = pd.read_csv(bids_mappings_file, sep='\t')
+        if df_mappings["session"].isna().all():
+            df_mappings.drop(columns="session", inplace=True)
+            df_mappings.to_csv(bids_mappings_file, sep='\t', index=False)
+
+
 def get_propertieshelp(propertieskey: str) -> str:
     """
     Reads the description of a matching attributes key in the source dictionary

--- a/bidscoin/bidscoiner.py
+++ b/bidscoin/bidscoiner.py
@@ -56,12 +56,6 @@ def bidscoiner(rawfolder: str, bidsfolder: str, subjects: list=(), force: bool=F
     # Create a code/bidscoin subfolder
     (bidsfolder/'code'/'bidscoin').mkdir(parents=True, exist_ok=True)
 
-    # Delete bids_mappings file if it exists
-    bids_mappings_file = bidsfolder / 'code' / 'bidscoin' / 'bids_mappings.tsv'
-    if bids_mappings_file.exists():
-        LOGGER.info('Deleting old code/bidscoin/bids_mappings.tsv')
-        bids_mappings_file.unlink()
-
     # Create a dataset description file if it does not exist
     dataset_file = bidsfolder/'dataset_description.json'
     generatedby  = [{"Name":"BIDScoin", 'Version':__version__, 'Description:':'A flexible GUI application suite that converts source datasets to BIDS', 'CodeURL':'https://github.com/Donders-Institute/bidscoin'}]
@@ -179,9 +173,6 @@ def bidscoiner(rawfolder: str, bidsfolder: str, subjects: list=(), force: bool=F
             LOGGER.info('')
             if not jobids:
 
-                # delete session column from bids_mappings if no sessions
-                bids.drop_session_from_bids_mappings(bids_mappings_file)
-
                 LOGGER.info('============== HPC FINISH =============')
                 LOGGER.info('')
                 return
@@ -238,9 +229,6 @@ def bidscoiner(rawfolder: str, bidsfolder: str, subjects: list=(), force: bool=F
 
         if not DEBUG:
             shutil.rmtree(bidsfolder/'HPC_work', ignore_errors=True)
-
-        # delete session column from bids_mappings if no sessions
-        bids.drop_session_from_bids_mappings(bids_mappings_file)
 
         LOGGER.info('')
         LOGGER.info('============== HPC FINISH =============')
@@ -309,8 +297,6 @@ def bidscoiner(rawfolder: str, bidsfolder: str, subjects: list=(), force: bool=F
                     if unpacked:
                         shutil.rmtree(sesfolder)
 
-    # delete session column from bids_mappings if no sessions
-    bids.drop_session_from_bids_mappings(bids_mappings_file)
 
     LOGGER.info('-------------- FINISHED! ------------')
     LOGGER.info('')

--- a/bidscoin/bidscoiner.py
+++ b/bidscoin/bidscoiner.py
@@ -172,7 +172,6 @@ def bidscoiner(rawfolder: str, bidsfolder: str, subjects: list=(), force: bool=F
 
             LOGGER.info('')
             if not jobids:
-
                 LOGGER.info('============== HPC FINISH =============')
                 LOGGER.info('')
                 return
@@ -296,7 +295,6 @@ def bidscoiner(rawfolder: str, bidsfolder: str, subjects: list=(), force: bool=F
                     # Clean-up the temporary unpacked data
                     if unpacked:
                         shutil.rmtree(sesfolder)
-
 
     LOGGER.info('-------------- FINISHED! ------------')
     LOGGER.info('')

--- a/bidscoin/bidscoiner.py
+++ b/bidscoin/bidscoiner.py
@@ -56,6 +56,12 @@ def bidscoiner(rawfolder: str, bidsfolder: str, subjects: list=(), force: bool=F
     # Create a code/bidscoin subfolder
     (bidsfolder/'code'/'bidscoin').mkdir(parents=True, exist_ok=True)
 
+    # Delete bids_mappings file if it exists
+    bids_mappings_file = bidsfolder / 'code' / 'bidscoin' / 'bids_mappings.tsv'
+    if bids_mappings_file.exists():
+        LOGGER.info('Deleting old code/bidscoin/bids_mappings.tsv')
+        bids_mappings_file.unlink()
+
     # Create a dataset description file if it does not exist
     dataset_file = bidsfolder/'dataset_description.json'
     generatedby  = [{"Name":"BIDScoin", 'Version':__version__, 'Description:':'A flexible GUI application suite that converts source datasets to BIDS', 'CodeURL':'https://github.com/Donders-Institute/bidscoin'}]
@@ -172,6 +178,10 @@ def bidscoiner(rawfolder: str, bidsfolder: str, subjects: list=(), force: bool=F
 
             LOGGER.info('')
             if not jobids:
+
+                # delete session column from bids_mappings if no sessions
+                bids.drop_session_from_bids_mappings(bids_mappings_file)
+
                 LOGGER.info('============== HPC FINISH =============')
                 LOGGER.info('')
                 return
@@ -228,6 +238,9 @@ def bidscoiner(rawfolder: str, bidsfolder: str, subjects: list=(), force: bool=F
 
         if not DEBUG:
             shutil.rmtree(bidsfolder/'HPC_work', ignore_errors=True)
+
+        # delete session column from bids_mappings if no sessions
+        bids.drop_session_from_bids_mappings(bids_mappings_file)
 
         LOGGER.info('')
         LOGGER.info('============== HPC FINISH =============')
@@ -295,6 +308,9 @@ def bidscoiner(rawfolder: str, bidsfolder: str, subjects: list=(), force: bool=F
                     # Clean-up the temporary unpacked data
                     if unpacked:
                         shutil.rmtree(sesfolder)
+
+    # delete session column from bids_mappings if no sessions
+    bids.drop_session_from_bids_mappings(bids_mappings_file)
 
     LOGGER.info('-------------- FINISHED! ------------')
     LOGGER.info('')

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -13,7 +13,6 @@ from bids_validator import BIDSValidator
 from typing import Union, List
 from pathlib import Path
 from bidscoin import bcoin, bids, lsdirs, due, Doi
-from bidscoin.bids import BidsMapping
 from bidscoin.utilities import physio
 try:
     from nibabel.testing import data_path
@@ -229,7 +228,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
         scans_table.index.name = 'filename'
 
     # Process all the source files or run subfolders
-    bids_mappings: List[BidsMapping] = []
+    matched_runs: List[dict] = []
     sourcefile = Path()
     for source in sources:
 
@@ -248,18 +247,15 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
         # Check if we should ignore this run
         if datasource.datatype in bidsmap['Options']['bidscoin']['ignoretypes']:
             LOGGER.info(f"--> Leaving out: {source}")
-            bids_mappings.append(BidsMapping(source, {Path(bidsses / 'X')}, datasource.datatype, run))
             continue
 
         # Check if we already know this run
         if not match:
             LOGGER.error(f"--> Skipping unknown '{datasource.datatype}' run: {sourcefile}\n-> Re-run the bidsmapper and delete {bidsses} to solve this warning")
-            bids_mappings.append(BidsMapping(source, {Path(bidsses / 'skipped')}, datasource.datatype, run))
             continue
 
         LOGGER.info(f"--> Coining: {source}")
-        bids_mapping = BidsMapping(source, set(), datasource.datatype, run)
-        bids_mappings.append(bids_mapping)
+        matched_runs.append(run)
 
         # Create the BIDS session/datatype output folder
         suffix = datasource.dynamicvalue(run['bids']['suffix'], True, True)
@@ -302,7 +298,6 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                 physiodata = physio.readphysio(sourcefile)
                 physio.physio2tsv(physiodata, outfolder/bidsname)
                 jsonfiles.update(outfolder.glob(f"{bidsname}.json"))  # add existing created json files: bidsname.json
-                bids_mapping.targets.add((outfolder / bidsname).with_suffix('.tsv.gz'))
             except Exception as physioerror:
                 LOGGER.error(f"Could not read/convert physiological file: {sourcefile}\n{physioerror}")
                 continue
@@ -319,7 +314,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                 if not list(outfolder.glob(f"{bidsname}.*nii*")): continue
 
             jsonfiles.update(outfolder.glob(f"{bidsname}.json"))  # add existing created json files: bidsname.json
-            bids_mapping.targets.update(outfolder.glob(f"{bidsname}.*[!json]"))
+            run["targets"].update(outfolder.glob(f"{bidsname}.*[!json]"))  # add files created using this bidsmap run-item (except sidecars)
 
             # Handle the ABCD GE pepolar sequence
             extrafile = list(outfolder.glob(f"{bidsname}a.nii*"))
@@ -433,7 +428,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                 if newbidsfile.is_file():
                     LOGGER.warning(f"Overwriting existing {newbidsfile} file -- check your results carefully!")
                 dcm2niixfile.replace(newbidsfile)
-                bids_mapping.targets.add(newbidsfile)
+                run["targets"].add(newbidsfile)
 
                 # Rename all associated files (i.e. the json-, bval- and bvec-files)
                 oldjsonfile = dcm2niixfile.with_suffix('').with_suffix('.json')
@@ -467,8 +462,8 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                             LOGGER.verbose(f"Removing BIDS-invalid b0-file: {bfile} -> {jsonfile}")
                             metadata[ext[1:]] = bdata.values.tolist()
                             bfile.unlink()
-                            if bfile in bids_mapping.targets:
-                                bids_mapping.targets.remove(bfile)
+                            if bfile in run["targets"]:
+                                run["targets"].remove(bfile)
 
             # Save the meta-data to the json sidecar-file
             with jsonfile.open('w') as json_fid:
@@ -498,9 +493,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                 scans_table.loc[scanpath.as_posix(), 'acq_time'] = acq_time
 
     # Handle dynamic index for run-1
-    bids.rename_runless_to_run1(bids_mappings, scans_table)
-    # Write bids mappings
-    bids.add_bids_mappings(bids_mappings, session, bidsfolder, bidsses)
+    bids.rename_runless_to_run1(matched_runs, scans_table)
 
     # Write the scans_table to disk
     LOGGER.verbose(f"Writing acquisition time data to: {scans_tsv}")

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -297,7 +297,8 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
             try:
                 physiodata = physio.readphysio(sourcefile)
                 physio.physio2tsv(physiodata, outfolder/bidsname)
-                jsonfiles.update(outfolder.glob(f"{bidsname}.json"))  # add existing created json files: bidsname.json
+                jsonfiles.update(outfolder.glob(f"{bidsname}.json"))            # add existing created json files: bidsname.json
+                datasource.targets.update(outfolder.glob(f"{bidsname}.*tsv*"))  # Add nifti files created using this run-item
             except Exception as physioerror:
                 LOGGER.error(f"Could not read/convert physiological file: {sourcefile}\n{physioerror}")
                 continue

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -313,8 +313,8 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
             if bcoin.run_command(command):
                 if not list(outfolder.glob(f"{bidsname}.*nii*")): continue
 
-            jsonfiles.update(outfolder.glob(f"{bidsname}.json"))  # add existing created json files: bidsname.json
-            datasource.targets.update(outfolder.glob(f"{bidsname}.*[!json]"))    # Add files created using this run-item (except sidecars)
+            jsonfiles.update(outfolder.glob(f"{bidsname}.json"))            # add existing created json files: bidsname.json
+            datasource.targets.update(outfolder.glob(f"{bidsname}.*nii*"))  # Add nifti files created using this run-item
 
             # Handle the ABCD GE pepolar sequence
             extrafile = list(outfolder.glob(f"{bidsname}a.nii*"))
@@ -428,6 +428,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                 if newbidsfile.is_file():
                     LOGGER.warning(f"Overwriting existing {newbidsfile} file -- check your results carefully!")
                 dcm2niixfile.replace(newbidsfile)
+                datasource.targets.remove(dcm2niixfile)
                 datasource.targets.add(newbidsfile)
 
                 # Rename all associated files (i.e. the json-, bval- and bvec-files)
@@ -462,8 +463,6 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                             LOGGER.verbose(f"Removing BIDS-invalid b0-file: {bfile} -> {jsonfile}")
                             metadata[ext[1:]] = bdata.values.tolist()
                             bfile.unlink()
-                            if bfile in datasource.targets:
-                                datasource.targets.remove(bfile)
 
             # Save the meta-data to the json sidecar-file
             with jsonfile.open('w') as json_fid:

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -267,7 +267,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
         bidsignore = bids.check_ignore(datasource.datatype, bidsmap['Options']['bidscoin']['bidsignore'])
         bidsname   = bids.get_bidsname(subid, sesid, run, not bidsignore, runtime=True)
         bidsignore = bidsignore or bids.check_ignore(bidsname+'.json', bidsmap['Options']['bidscoin']['bidsignore'], 'file')
-        bidsname   = bids.increment_runindex(outfolder, bidsname, run, scans_table)
+        bidsname   = bids.increment_runindex(outfolder, bidsname, run)
         jsonfiles  = set()  # Set -> Collect the associated json-files (for updating them later) -- possibly > 1
 
         # Check if the bidsname is valid
@@ -419,7 +419,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                         LOGGER.warning(f"The {newbidsname} image is a derivate / not BIDS-compliant -- you can probably delete it safely and update {scans_tsv}")
 
                 # Save the NIfTI file with the newly constructed name
-                newbidsname = bids.increment_runindex(outfolder, newbidsname, run, scans_table)                 # Update the runindex now that the acq-label has changed
+                newbidsname = bids.increment_runindex(outfolder, newbidsname, run)                 # Update the runindex now that the acq-label has changed
                 newbidsfile = outfolder/newbidsname
                 LOGGER.verbose(f"Found dcm2niix {postfixes} postfixes, renaming\n{dcm2niixfile} ->\n{newbidsfile}")
                 if newbidsfile.is_file():

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -314,7 +314,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                 if not list(outfolder.glob(f"{bidsname}.*nii*")): continue
 
             jsonfiles.update(outfolder.glob(f"{bidsname}.json"))  # add existing created json files: bidsname.json
-            run["targets"].update(outfolder.glob(f"{bidsname}.*[!json]"))  # add files created using this bidsmap run-item (except sidecars)
+            datasource.targets += outfolder.glob(f"{bidsname}.*[!json]")    # Add files created using this run-item (except sidecars)
 
             # Handle the ABCD GE pepolar sequence
             extrafile = list(outfolder.glob(f"{bidsname}a.nii*"))
@@ -428,7 +428,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                 if newbidsfile.is_file():
                     LOGGER.warning(f"Overwriting existing {newbidsfile} file -- check your results carefully!")
                 dcm2niixfile.replace(newbidsfile)
-                run["targets"].add(newbidsfile)
+                datasource.targets.append(newbidsfile)
 
                 # Rename all associated files (i.e. the json-, bval- and bvec-files)
                 oldjsonfile = dcm2niixfile.with_suffix('').with_suffix('.json')
@@ -462,8 +462,8 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                             LOGGER.verbose(f"Removing BIDS-invalid b0-file: {bfile} -> {jsonfile}")
                             metadata[ext[1:]] = bdata.values.tolist()
                             bfile.unlink()
-                            if bfile in run["targets"]:
-                                run["targets"].remove(bfile)
+                            if bfile in datasource.targets:
+                                datasource.targets.remove(bfile)
 
             # Save the meta-data to the json sidecar-file
             with jsonfile.open('w') as json_fid:

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -447,7 +447,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
         for jsonfile in sorted(jsonfiles):
 
             # Load / copy over the source meta-data
-            metadata = bids.updatemetadata(sourcefile, jsonfile, run['meta'], options['meta'], datasource)
+            metadata = bids.updatemetadata(datasource, jsonfile, run['meta'], options['meta'])
 
             # Remove the bval/bvec files of sbref- and inv-images (produced by dcm2niix but not allowed by the BIDS specifications)
             if (datasource.datatype=='dwi' and suffix=='sbref') or (datasource.datatype=='fmap' and suffix=='epi'):

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -497,6 +497,9 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                 scanpath = outputfile[0].relative_to(bidsses)
                 scans_table.loc[scanpath.as_posix(), 'acq_time'] = acq_time
 
+    # Handle dynamic index for run-1
+    bids.rename_runless_to_run1(bids_mappings, scans_table)
+
     # Write the scans_table to disk
     LOGGER.verbose(f"Writing acquisition time data to: {scans_tsv}")
     scans_table.sort_values(by=['acq_time','filename'], inplace=True)

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -499,6 +499,8 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
 
     # Handle dynamic index for run-1
     bids.rename_runless_to_run1(bids_mappings, scans_table)
+    # Write bids mappings
+    bids.add_bids_mappings(bids_mappings, session, bidsfolder, bidsses)
 
     # Write the scans_table to disk
     LOGGER.verbose(f"Writing acquisition time data to: {scans_tsv}")

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -429,7 +429,6 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                 if newbidsfile.is_file():
                     LOGGER.warning(f"Overwriting existing {newbidsfile} file -- check your results carefully!")
                 dcm2niixfile.replace(newbidsfile)
-                datasource.targets.remove(dcm2niixfile)
                 datasource.targets.add(newbidsfile)
 
                 # Rename all associated files (i.e. the json-, bval- and bvec-files)

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -314,7 +314,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                 if not list(outfolder.glob(f"{bidsname}.*nii*")): continue
 
             jsonfiles.update(outfolder.glob(f"{bidsname}.json"))  # add existing created json files: bidsname.json
-            datasource.targets += outfolder.glob(f"{bidsname}.*[!json]")    # Add files created using this run-item (except sidecars)
+            datasource.targets.update(outfolder.glob(f"{bidsname}.*[!json]"))    # Add files created using this run-item (except sidecars)
 
             # Handle the ABCD GE pepolar sequence
             extrafile = list(outfolder.glob(f"{bidsname}a.nii*"))
@@ -428,7 +428,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                 if newbidsfile.is_file():
                     LOGGER.warning(f"Overwriting existing {newbidsfile} file -- check your results carefully!")
                 dcm2niixfile.replace(newbidsfile)
-                datasource.targets.append(newbidsfile)
+                datasource.targets.add(newbidsfile)
 
                 # Rename all associated files (i.e. the json-, bval- and bvec-files)
                 oldjsonfile = dcm2niixfile.with_suffix('').with_suffix('.json')

--- a/bidscoin/plugins/nibabel2bids.py
+++ b/bidscoin/plugins/nibabel2bids.py
@@ -236,7 +236,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> None:
 
         # Load / copy over the source meta-data
         sidecar  = bidsfile.with_suffix('').with_suffix('.json')
-        metadata = bids.updatemetadata(sourcefile, sidecar, run['meta'], meta, datasource)
+        metadata = bids.updatemetadata(datasource, sidecar, run['meta'], meta)
         with sidecar.open('w') as json_fid:
             json.dump(metadata, json_fid, indent=4)
 

--- a/bidscoin/plugins/nibabel2bids.py
+++ b/bidscoin/plugins/nibabel2bids.py
@@ -213,7 +213,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> None:
         bidsignore = bids.check_ignore(datasource.datatype, bidsmap['Options']['bidscoin']['bidsignore'])
         bidsname   = bids.get_bidsname(subid, sesid, run, not bidsignore, runtime=True)
         bidsignore = bidsignore or bids.check_ignore(bidsname+'.json', bidsmap['Options']['bidscoin']['bidsignore'], 'file')
-        bidsname   = bids.increment_runindex(outfolder, bidsname, run, scans_table)
+        bidsname   = bids.increment_runindex(outfolder, bidsname, run)
         bidsfile   = (outfolder/bidsname).with_suffix(ext)
 
         # Check if the bidsname is valid

--- a/bidscoin/plugins/nibabel2bids.py
+++ b/bidscoin/plugins/nibabel2bids.py
@@ -232,7 +232,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> None:
 
         # Save the sourcefile as a BIDS NIfTI file
         nib.save(nib.load(sourcefile), bidsfile)
-        datasource.targets.append(bidsfile)
+        datasource.targets.add(bidsfile)
 
         # Load / copy over the source meta-data
         sidecar  = bidsfile.with_suffix('').with_suffix('.json')

--- a/bidscoin/plugins/nibabel2bids.py
+++ b/bidscoin/plugins/nibabel2bids.py
@@ -232,7 +232,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> None:
 
         # Save the sourcefile as a BIDS NIfTI file
         nib.save(nib.load(sourcefile), bidsfile)
-        run["targets"].add(bidsfile)
+        datasource.targets.append(bidsfile)
 
         # Load / copy over the source meta-data
         sidecar  = bidsfile.with_suffix('').with_suffix('.json')

--- a/bidscoin/plugins/spec2nii2bids.py
+++ b/bidscoin/plugins/spec2nii2bids.py
@@ -262,7 +262,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
         datasource.targets += outfolder.glob(f"{bidsname}.*[!json]")
 
         # Load / copy over and adapt the newly produced json sidecar-file (NB: assumes every NIfTI-file comes with a json-file)
-        metadata = bids.updatemetadata(sourcefile, sidecar, run['meta'], options['meta'], datasource)
+        metadata = bids.updatemetadata(datasource, sidecar, run['meta'], options['meta'])
         with sidecar.open('w') as json_fid:
             json.dump(metadata, json_fid, indent=4)
 

--- a/bidscoin/plugins/spec2nii2bids.py
+++ b/bidscoin/plugins/spec2nii2bids.py
@@ -12,7 +12,6 @@ from typing import List, Union
 from bids_validator import BIDSValidator
 from pathlib import Path
 from bidscoin import bcoin, bids, due, Doi
-from bidscoin.bids import BidsMapping
 
 LOGGER = logging.getLogger(__name__)
 
@@ -174,11 +173,9 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
 
     # Get the subject identifiers and the BIDS root folder from the bidsses folder
     if bidsses.name.startswith('ses-'):
-        bidsfolder = bidsses.parent.parent
         subid      = bidsses.parent.name
         sesid      = bidsses.name
     else:
-        bidsfolder = bidsses.parent
         subid      = bidsses.name
         sesid      = ''
 
@@ -200,7 +197,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
         scans_table.index.name = 'filename'
 
     # Loop over all MRS source data files and convert them to BIDS
-    bids_mappings: List[BidsMapping] = []
+    matched_runs: List[dict] = []
     for sourcefile in sourcefiles:
 
         # Get a data source, a matching run from the bidsmap
@@ -210,18 +207,15 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
         # Check if we should ignore this run
         if datasource.datatype in bidsmap['Options']['bidscoin']['ignoretypes']:
             LOGGER.info(f"--> Leaving out: {sourcefile}")
-            bids_mappings.append(BidsMapping(sourcefile, {Path(bidsses / 'X')}, datasource.datatype, run))
             continue
 
         # Check that we know this run
         if index is None:
             LOGGER.error(f"Skipping unknown '{datasource.datatype}' run: {sourcefile}\n-> Re-run the bidsmapper and delete the MRS output data in {bidsses} to solve this warning")
-            bids_mappings.append(BidsMapping(sourcefile, {Path(bidsses / 'skipped')}, datasource.datatype, run))
             continue
 
         LOGGER.info(f"--> Coining: {sourcefile}")
-        bids_mapping = BidsMapping(sourcefile, set(), datasource.datatype, run)
-        bids_mappings.append(bids_mapping)
+        matched_runs.append(run)
 
         # Create the BIDS session/datatype output folder
         outfolder = bidsses/datasource.datatype
@@ -264,7 +258,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
         if bcoin.run_command(f'{command} {dformat} -j -f "{bidsname}" -o "{outfolder}" {args} {arg} "{sourcefile}"'):
             if not list(outfolder.glob(f"{bidsname}.nii*")): continue
 
-        bids_mapping.targets.update(outfolder.glob(f"{bidsname}.*[!json]"))
+        run["targets"].update(outfolder.glob(f"{bidsname}.*[!json]"))  # add files created using this bidsmap run-item (except sidecars)
 
         # Load / copy over and adapt the newly produced json sidecar-file (NB: assumes every NIfTI-file comes with a json-file)
         metadata = bids.updatemetadata(sourcefile, sidecar, run['meta'], options['meta'], datasource)
@@ -294,9 +288,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
             scans_table.loc[sidecar.with_suffix('.nii.gz').relative_to(bidsses).as_posix(), 'acq_time'] = acq_time
 
     # Handle dynamic index for run-1
-    bids.rename_runless_to_run1(bids_mappings, scans_table)
-    # Write bids mappings
-    bids.add_bids_mappings(bids_mappings, session, bidsfolder, bidsses)
+    bids.rename_runless_to_run1(matched_runs, scans_table)
 
     # Write the scans_table to disk
     LOGGER.verbose(f"Writing acquisition time data to: {scans_tsv}")

--- a/bidscoin/plugins/spec2nii2bids.py
+++ b/bidscoin/plugins/spec2nii2bids.py
@@ -223,7 +223,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
         bidsignore = bids.check_ignore(datasource.datatype, bidsmap['Options']['bidscoin']['bidsignore'])
         bidsname   = bids.get_bidsname(subid, sesid, run, not bidsignore, runtime=True)
         bidsignore = bidsignore or bids.check_ignore(bidsname+'.json', bidsmap['Options']['bidscoin']['bidsignore'], 'file')
-        bidsname   = bids.increment_runindex(outfolder, bidsname, run, scans_table)
+        bidsname   = bids.increment_runindex(outfolder, bidsname, run)
         sidecar    = (outfolder/bidsname).with_suffix('.json')
 
         # Check if the bidsname is valid

--- a/bidscoin/plugins/spec2nii2bids.py
+++ b/bidscoin/plugins/spec2nii2bids.py
@@ -259,7 +259,7 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
             if not list(outfolder.glob(f"{bidsname}.nii*")): continue
 
         # Add files created using this bidsmap run-item (except sidecars)
-        datasource.targets += outfolder.glob(f"{bidsname}.*[!json]")
+        datasource.targets.add(outfolder.glob(f"{bidsname}.*[!json]"))
 
         # Load / copy over and adapt the newly produced json sidecar-file (NB: assumes every NIfTI-file comes with a json-file)
         metadata = bids.updatemetadata(datasource, sidecar, run['meta'], options['meta'])

--- a/bidscoin/plugins/spec2nii2bids.py
+++ b/bidscoin/plugins/spec2nii2bids.py
@@ -258,7 +258,8 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
         if bcoin.run_command(f'{command} {dformat} -j -f "{bidsname}" -o "{outfolder}" {args} {arg} "{sourcefile}"'):
             if not list(outfolder.glob(f"{bidsname}.nii*")): continue
 
-        run["targets"].update(outfolder.glob(f"{bidsname}.*[!json]"))  # add files created using this bidsmap run-item (except sidecars)
+        # Add files created using this bidsmap run-item (except sidecars)
+        datasource.targets += outfolder.glob(f"{bidsname}.*[!json]")
 
         # Load / copy over and adapt the newly produced json sidecar-file (NB: assumes every NIfTI-file comes with a json-file)
         metadata = bids.updatemetadata(sourcefile, sidecar, run['meta'], options['meta'], datasource)

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -474,7 +474,7 @@ def test_rename_runless_to_run1(tmp_path):
             outfile = (outfolder/file_name).with_suffix(suffix)
             outfile.touch()
             if suffix == '.nii.gz':
-                run['datasource'].targets.append(outfile)
+                run['datasource'].targets.add(outfile)
                 matched_runs.append(run)
 
     # Create the scans table

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -461,7 +461,7 @@ def test_rename_runless_to_run1(tmp_path):
     """Test <<>> index renaming run-less files to run-1 files."""
 
     # Create data
-    run                  = bids.get_run_()
+    run                  = bids.create_run()
     run['bids']          = {'run': '<<>>'}
     matched_runs         = []
     old_runless_bidsname = 'sub-01_T1w'

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -327,7 +327,7 @@ def test_append_run(test_bidsmap):
 
     # Append the run elsewhere in the bidsmap
     bids.append_run(bidsmap, run)
-    assert bidsmap['Foo']['Bar'][0]['provenance'] == run['provenance']
+    assert Path(bidsmap['Foo']['Bar'][0]['provenance']) == Path(run['provenance'])
 
 
 def test_update_bidsmap(test_bidsmap):
@@ -341,8 +341,8 @@ def test_update_bidsmap(test_bidsmap):
 
     # Update the bidsmap
     bids.update_bidsmap(bidsmap, 'func', run)
-    assert bidsmap['DICOM']['anat'][-1]['provenance'] == run['provenance']
-    assert bidsmap['DICOM']['func'] [0]['provenance'] != run['provenance']
+    assert Path(bidsmap['DICOM']['anat'][-1]['provenance']) == Path(run['provenance'])
+    assert Path(bidsmap['DICOM']['func'] [0]['provenance']) != Path(run['provenance'])
 
     # Modify the last anat run-item and update the bidsmap
     run['bids']['foo'] = 'bar'

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -681,6 +681,42 @@ def test_add_bids_mappings__session(tmp_path):
     assert result_df.equals(expected_df)
 
 
+def test_add_bids_mappings__derivatives(tmp_path):
+    """Test creating 'bids_mappings.tsv' with derivatives."""
+
+    sessionfolder = tmp_path / 'source' / 'sub-01'
+    bidsfolder = tmp_path / 'bids'
+    bidsses = tmp_path / 'bids' / 'sub-01'
+    out = bidsfolder / "code" / "bidscoin" / "bids_mappings.tsv"
+
+    bids_mappings = [
+        BidsMapping(
+            sessionfolder / 'fmap_source',
+            {bidsfolder / 'derivatives' / 'SIEMENS' / 'fmap' / 'sub-01_TB1RFM.nii.gz'},
+            'fmap',
+            {'bids': {'run': '<<>>'}, 'attributes': {'SeriesDescription': 't1'}}
+        )
+    ]
+    expected_df = pd.DataFrame(
+        {
+            "subject": ["sub-01"],
+            "session": ['NaN'],
+            "SeriesDescription": ["t1"],
+            "source": [str(Path("sub-01") / "fmap_source")],
+            "BIDS_mapping": [str(Path("derivatives") / "SIEMENS" / "fmap" / "sub-01_TB1RFM.nii.gz")]
+        }
+    )
+
+    # Run the function
+    bids.add_bids_mappings(bids_mappings, sessionfolder, bidsfolder, bidsses)
+
+    # Check the results
+    assert out.is_file() is True
+    result_df = pd.read_csv(out, sep='\t')
+    result_df['session'].fillna('NaN', inplace=True)
+    assert result_df.equals(expected_df)
+
+
 def test_drop_session_from_bids_mappings__session_dropped(tmp_path):
 
     out = tmp_path / 'bids' / "code" / "bidscoin" / "bids_mappings.tsv"

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -664,6 +664,74 @@ def test_add_bids_mappings__session(tmp_path):
     assert result_df.equals(expected_df)
 
 
+def test_drop_session_from_bids_mappings__session_dropped(tmp_path):
+
+    out = tmp_path / 'bids' / "code" / "bidscoin" / "bids_mappings.tsv"
+    existing_df = pd.DataFrame(
+        {
+            "subject": ["sub-01", "sub-01", "sub-01"],
+            "session": [None, None, None],
+            "SeriesDescription": ["t1", "bold", "bold"],
+            "source": ["sub-01/anat_source", "sub-01/func_source", "sub-01/func_source"],
+            "BIDS_mapping": [
+                "anat/sub-01_T1w.nii.gz",
+                "func/sub-01_task-dummy_bold.nii.gz",
+                "func/sub-01_task-dummy_part-phase_bold.nii.gz"
+            ]
+        }
+    )
+    out.parent.mkdir(parents=True)
+    existing_df.to_csv(out, sep='\t', index=False)
+    expected_df = pd.DataFrame(
+        {
+            "subject": ["sub-01", "sub-01", "sub-01"],
+            "SeriesDescription": ["t1", "bold", "bold"],
+            "source": ["sub-01/anat_source", "sub-01/func_source", "sub-01/func_source"],
+            "BIDS_mapping": [
+                "anat/sub-01_T1w.nii.gz",
+                "func/sub-01_task-dummy_bold.nii.gz",
+                "func/sub-01_task-dummy_part-phase_bold.nii.gz"
+            ]
+        }
+    )
+
+    # Run the function
+    bids.drop_session_from_bids_mappings(out)
+
+    # Check the results
+    assert out.is_file() is True
+    result_df = pd.read_csv(out, sep='\t')
+    assert result_df.equals(expected_df)
+
+
+def test_drop_session_from_bids_mappings__session_not_dropped(tmp_path):
+
+    out = tmp_path / 'bids' / "code" / "bidscoin" / "bids_mappings.tsv"
+    expected_df = pd.DataFrame(
+        {
+            "subject": ["sub-01", "sub-01", "sub-01"],
+            "session": ['ses-1', 'ses-1', 'ses-1'],
+            "SeriesDescription": ["t1", "bold", "bold"],
+            "source": ["sub-01/anat_source", "sub-01/func_source", "sub-01/func_source"],
+            "BIDS_mapping": [
+                "anat/sub-01_T1w.nii.gz",
+                "func/sub-01_task-dummy_bold.nii.gz",
+                "func/sub-01_task-dummy_part-phase_bold.nii.gz"
+            ]
+        }
+    )
+    out.parent.mkdir(parents=True)
+    expected_df.to_csv(out, sep='\t', index=False)
+
+    # Run the function
+    bids.drop_session_from_bids_mappings(out)
+
+    # Check the results
+    assert out.is_file() is True
+    result_df = pd.read_csv(out, sep='\t')
+    assert result_df.equals(expected_df)
+
+
 def test_get_bidsname(raw_dicomdir):
 
     dicomfile   = raw_dicomdir/'Doe^Archibald'/'01-XR C Spine Comp Min 4 Views'/'001-Cervical LAT'/'6154'

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -528,11 +528,13 @@ def test_add_bids_mappings__new(tmp_path):
             "subject": ["sub-01", "sub-01", "sub-01"],
             "session": ['NaN', 'NaN', 'NaN'],
             "SeriesDescription": ["t1", "bold", "bold"],
-            "source": ["sub-01/anat_source", "sub-01/func_source", "sub-01/func_source"],
+            "source": [str(Path("sub-01") / src) for src in ["anat_source", "func_source", "func_source"]],
             "BIDS_mapping": [
-                "anat/sub-01_T1w.nii.gz",
-                "func/sub-01_task-dummy_bold.nii.gz",
-                "func/sub-01_task-dummy_part-phase_bold.nii.gz"
+                str(Path(outdir) / file) for outdir, file in [
+                    ("anat", "sub-01_T1w.nii.gz"),
+                    ("func", "sub-01_task-dummy_bold.nii.gz"),
+                    ("func", "sub-01_task-dummy_part-phase_bold.nii.gz")
+                ]
             ]
         }
     )
@@ -560,11 +562,13 @@ def test_add_bids_mappings__combined(tmp_path):
         {
             "subject": ["sub-01", "sub-01", "sub-01"],
             "SeriesDescription": ["t1", "bold", "bold"],
-            "source": ["sub-01/anat_source", "sub-01/func_source", "sub-01/func_source"],
+            "source": [str(Path("sub-01") / src) for src in ["anat_source", "func_source", "func_source"]],
             "BIDS_mapping": [
-                "anat/sub-01_T1w.nii.gz",
-                "func/sub-01_task-dummy_bold.nii.gz",
-                "func/sub-01_task-dummy_part-phase_bold.nii.gz"
+                str(Path(outdir) / file) for outdir, file in [
+                    ("anat", "sub-01_T1w.nii.gz"),
+                    ("func", "sub-01_task-dummy_bold.nii.gz"),
+                    ("func", "sub-01_task-dummy_part-phase_bold.nii.gz")
+                ]
             ]
         }
     )
@@ -594,14 +598,25 @@ def test_add_bids_mappings__combined(tmp_path):
             "subject": ["sub-01", "sub-01", "sub-01", "sub-02", "sub-02", "sub-02"],
             "session": ['NaN', 'NaN', 'NaN', 'NaN', 'NaN', 'NaN'],
             "SeriesDescription": ["t1", "bold", "bold", "t1", "bold", "bold"],
-            "source": ["sub-01/anat_source", "sub-01/func_source", "sub-01/func_source", "sub-02/anat_source", "sub-02/func_source", "sub-02/func_source"],
+            "source": [
+                str(Path(outdir) / file) for outdir, file in [
+                    ("sub-01", "anat_source"),
+                    ("sub-01", "func_source"),
+                    ("sub-01", "func_source"),
+                    ("sub-02", "anat_source"),
+                    ("sub-02", "func_source"),
+                    ("sub-02", "func_source"),
+                ]
+            ],
             "BIDS_mapping": [
-                "anat/sub-01_T1w.nii.gz",
-                "func/sub-01_task-dummy_bold.nii.gz",
-                "func/sub-01_task-dummy_part-phase_bold.nii.gz",
-                "anat/sub-02_T1w.nii.gz",
-                "func/sub-02_task-dummy_bold.nii.gz",
-                "func/sub-02_task-dummy_part-phase_bold.nii.gz"
+                str(Path(outdir) / file) for outdir, file in [
+                    ("anat", "sub-01_T1w.nii.gz"),
+                    ("func", "sub-01_task-dummy_bold.nii.gz"),
+                    ("func", "sub-01_task-dummy_part-phase_bold.nii.gz"),
+                    ("anat", "sub-02_T1w.nii.gz"),
+                    ("func", "sub-02_task-dummy_bold.nii.gz"),
+                    ("func", "sub-02_task-dummy_part-phase_bold.nii.gz")
+                ]
             ]
         }
     )
@@ -646,11 +661,13 @@ def test_add_bids_mappings__session(tmp_path):
             "subject": ["sub-01", "sub-01", "sub-01"],
             "session": ['ses-01', 'ses-01', 'ses-01'],
             "SeriesDescription": ["t1", "bold", "bold"],
-            "source": ["ses-01/anat_source", "ses-01/func_source", "ses-01/func_source"],
+            "source": [str(Path("ses-01") / src) for src in ["anat_source", "func_source", "func_source"]],
             "BIDS_mapping": [
-                "anat/sub-01_ses-01_T1w.nii.gz",
-                "func/sub-01_ses-01_task-dummy_bold.nii.gz",
-                "func/sub-01_ses-01_task-dummy_part-phase_bold.nii.gz"
+                str(Path(outdir) / file) for outdir, file in [
+                    ("anat", "sub-01_ses-01_T1w.nii.gz"),
+                    ("func", "sub-01_ses-01_task-dummy_bold.nii.gz"),
+                    ("func", "sub-01_ses-01_task-dummy_part-phase_bold.nii.gz")
+                ]
             ]
         }
     )
@@ -672,11 +689,13 @@ def test_drop_session_from_bids_mappings__session_dropped(tmp_path):
             "subject": ["sub-01", "sub-01", "sub-01"],
             "session": [None, None, None],
             "SeriesDescription": ["t1", "bold", "bold"],
-            "source": ["sub-01/anat_source", "sub-01/func_source", "sub-01/func_source"],
+            "source": [str(Path("sub-01") / src) for src in ["anat_source", "func_source", "func_source"]],
             "BIDS_mapping": [
-                "anat/sub-01_T1w.nii.gz",
-                "func/sub-01_task-dummy_bold.nii.gz",
-                "func/sub-01_task-dummy_part-phase_bold.nii.gz"
+                str(Path(outdir) / file) for outdir, file in [
+                    ("anat", "sub-01_T1w.nii.gz"),
+                    ("func", "sub-01_task-dummy_bold.nii.gz"),
+                    ("func", "sub-01_task-dummy_part-phase_bold.nii.gz")
+                ]
             ]
         }
     )
@@ -686,11 +705,13 @@ def test_drop_session_from_bids_mappings__session_dropped(tmp_path):
         {
             "subject": ["sub-01", "sub-01", "sub-01"],
             "SeriesDescription": ["t1", "bold", "bold"],
-            "source": ["sub-01/anat_source", "sub-01/func_source", "sub-01/func_source"],
+            "source": [str(Path("sub-01") / src) for src in ["anat_source", "func_source", "func_source"]],
             "BIDS_mapping": [
-                "anat/sub-01_T1w.nii.gz",
-                "func/sub-01_task-dummy_bold.nii.gz",
-                "func/sub-01_task-dummy_part-phase_bold.nii.gz"
+                str(Path(outdir) / file) for outdir, file in [
+                    ("anat", "sub-01_T1w.nii.gz"),
+                    ("func", "sub-01_task-dummy_bold.nii.gz"),
+                    ("func", "sub-01_task-dummy_part-phase_bold.nii.gz")
+                ]
             ]
         }
     )
@@ -710,13 +731,15 @@ def test_drop_session_from_bids_mappings__session_not_dropped(tmp_path):
     expected_df = pd.DataFrame(
         {
             "subject": ["sub-01", "sub-01", "sub-01"],
-            "session": ['ses-1', 'ses-1', 'ses-1'],
+            "session": ['ses-01', 'ses-01', 'ses-01'],
             "SeriesDescription": ["t1", "bold", "bold"],
-            "source": ["sub-01/anat_source", "sub-01/func_source", "sub-01/func_source"],
+            "source": [str(Path("ses-01") / src) for src in ["anat_source", "func_source", "func_source"]],
             "BIDS_mapping": [
-                "anat/sub-01_T1w.nii.gz",
-                "func/sub-01_task-dummy_bold.nii.gz",
-                "func/sub-01_task-dummy_part-phase_bold.nii.gz"
+                str(Path(outdir) / file) for outdir, file in [
+                    ("anat", "sub-01_ses-01_T1w.nii.gz"),
+                    ("func", "sub-01_ses-01_task-dummy_bold.nii.gz"),
+                    ("func", "sub-01_ses-01_task-dummy_part-phase_bold.nii.gz")
+                ]
             ]
         }
     )

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -461,8 +461,9 @@ def test_rename_runless_to_run1(tmp_path):
     """Test <<>> index renaming run-less files to run-1 files."""
 
     # Create data
-    run                  = {'bids': {'run': '<<>>'}, 'targets': set()}
-    matched_runs        = []
+    run                  = bids.get_run_()
+    run['bids']          = {'run': '<<>>'}
+    matched_runs         = []
     old_runless_bidsname = 'sub-01_T1w'
     new_run1_bidsname    = 'sub-01_run-1_T1w'
     run2_bidsname        = 'sub-01_run-2_T1w'
@@ -473,7 +474,7 @@ def test_rename_runless_to_run1(tmp_path):
             outfile = (outfolder/file_name).with_suffix(suffix)
             outfile.touch()
             if suffix == '.nii.gz':
-                run["targets"].add(outfile)
+                run['datasource'].targets.append(outfile)
                 matched_runs.append(run)
 
     # Create the scans table
@@ -564,7 +565,7 @@ def test_updatemetadata(dcm_file, tmp_path):
                 'B0FieldIdentifier': 'Identifier_<<session>>'}
 
     # Test if the user metadata takes precedence
-    metadata = bids.updatemetadata(sourcefile, sidecar, usermeta, ['.json'], extdatasource)
+    metadata = bids.updatemetadata(extdatasource, sidecar, usermeta, ['.json'])
     assert metadata['PatientName']       == 'UserTest'
     assert metadata['DynamicName']       == 'CompressedSamples^MR1'
     assert metadata['B0FieldSource']     == 'Source_01'
@@ -572,10 +573,10 @@ def test_updatemetadata(dcm_file, tmp_path):
     assert not (outfolder/sourcefile.with_suffix('.jsn').name).is_file()
 
     # Test if the source metadata takes precedence
-    metadata = bids.updatemetadata(sourcefile, sidecar, {}, ['.jsn', '.json'], extdatasource)
+    metadata = bids.updatemetadata(extdatasource, sidecar, {}, ['.jsn', '.json'], sourcefile)
     assert metadata['PatientName'] == 'SourceTest'
     assert (outfolder/sourcefile.with_suffix('.jsn').name).is_file()
 
     # Test if the sidecar metadata takes precedence
-    metadata = bids.updatemetadata(sourcefile, sidecar, {}, [], extdatasource)
+    metadata = bids.updatemetadata(extdatasource, sidecar, {}, [])
     assert metadata['PatientName'] == 'SidecarTest'


### PR DESCRIPTION
Adding run-1 to files immediately when new run is detected introduces problems:

1. dcm2niix2bids: variable jsonfiles
Need to remove run-less file and add run-1 file

2. dcm2niix2bids: newbidsname via dcm2niix postfixes
- If bidsname changes via postfixes, run-index starts from the one that was already in old bidsname, although this new bidsname could be unique and therefore doesn’t need run-index. Function increment_runindex would need to check for that.
- If bidsname changes from run-less to run-2 via dcm2niix postfix in the same dcm2niix plugin run, again, need to remove run-less file and add run-1 file to jsonfiles. If it is the other way around, so from run-2 to run-less (after increment_runindex is adjusted for the case if bidsname contains run-index although it doesn’t need it), previously added run-1 with increment_runindex needs to be removed because it is no longer valid. This needs to be reflected in scans_table and in jsonfiles again.

I think this solution is not well maintainable since one needs to rely on the concrete order of functions called and increment_runindex is not standing on its own, since we need to later fix renamed files. With dcm2niix postfixes, files are being renamed back and forth, when run-1 is not needed in the first place, although we do not know it at the time of naming. Also, if in the future files are collected in new variables, these changes need to be reflected in all the variables and it is easy to forget to do that.

I suggest adding run-1 to files that need it (run-2 exists) and use <<>> run-index at the end of the plugin run, since at that time all the names of files are final and dcm2niix postfixes won’t change them. It also removes side effect from increment_runindex and makes it simpler.

I merged this fix with other suggestion I have: generate .tsv file with information what source was mapped to what bids files. I know that one can see in logs what was mapped to what, but having tsv file means one can quickly check the final names and that mappings are correct. We can see how the result mappings would look like also from bidsmap, but run-indexes and changes via dcm2niix postfixes are not there.
Maybe in the future, user could define what run data would he like to add as new column for easier check of mappings, for now I added SeriesDescription since a lot of files are mapped by that.

This bids_mappings.tsv file looks for example like this:
| subject | SeriesDescription         | source                                              | BIDS_mapping                                           |
|---------|--------------------------|-----------------------------------------------|----------------------------------------------|
| sub-01  | AAHead_Scout            | sub-01/std1_01_AAHead_Scout                 | X                                                |
| sub-01  | localizer                       | sub-01/std1_02_localizer                           | X                                            |
| sub-01  | t1_mprage_sag            | sub-01/std1_03_t1_mprage_sag                | anat/sub-01_T1w.nii.gz                       |
| sub-01  | bold_25iso_tr800-rest  | sub-01/std1_04_bold_25iso_tr800-rest     | func/sub-01_task-bold25isotr800rest_echo-1_bold.nii.gz |
| sub-01  | bold_25iso_tr800-rest  | sub-01/std1_04_bold_25iso_tr800-rest     | func/sub-01_task-bold25isotr800rest_echo-2_bold.nii.gz |
| sub-01  | bold_25iso_tr800-rest  | sub-01/std1_05_bold_25iso_tr800-rest     | func/sub-01_task-bold25isotr800rest_echo-1_part-phase_bold |
| sub-01  | bold_25iso_tr800-rest  | sub-01/std1_05_bold_25iso_tr800-rest     | func/sub-01_task-bold25isotr800rest_echo-2_part-phase_bold |
| sub-01  | bold_gre_map             | sub-01/std1_06_bold_gre_map                  | fmap/sub-01_magnitude1.nii.gz                |
| sub-01  | bold_gre_map             | sub-01/std1_06_bold_gre_map                  | fmap/sub-01_magnitude2.nii.gz                |
| sub-01  | bold_gre_map             | sub-01/std1_07_bold_gre_map                  | fmap/sub-01_phasediff.nii.gz                 |
