### PR TITLE
Append dcm2niix postfix to acq only if acq is not defined

### DIFF
--- a/bidscoin/bidseditor.py
+++ b/bidscoin/bidseditor.py
@@ -71,7 +71,10 @@ anon: Set this anonymization flag to 'y' to round off age and to discard acquisi
 
 meta: The file extensions of the associated / equally named (meta)data sourcefiles that are copied over as
     BIDS (sidecar) files, such as ['.json', '.tsv', '.tsv.gz']. You can use this to enrich json sidecar files,
-    or add data that is not supported by this plugin"""
+    or add data that is not supported by this plugin
+
+fallback: Fallback BIDS label for not mapped dcm2niix postfixes, allowed values are 'acq' or '' 
+    ('': not mapped postfixes are discarded)"""
 
 
 class MainWindow(QMainWindow):

--- a/bidscoin/heuristics/bidsmap_dccn.yaml
+++ b/bidscoin/heuristics/bidsmap_dccn.yaml
@@ -36,6 +36,7 @@ Options:
       args: -b y -z y -i n -l n     # Argument string that is passed to dcm2niix. Tip: SPM users may want to use '-z n' (which produces unzipped NIfTI's, see dcm2niix -h for more information)
       anon: y                       # Set this anonymization flag to 'y' to round off age and discard acquisition date from the meta data
       meta: [.json, .tsv, .tsv.gz]  # The file extensions of the equally named metadata sourcefiles that are copied over to the BIDS sidecar files
+      fallback: 'acq'               # Fallback BIDS label for not mapped dcm2niix postfixes, allowed values are 'acq' or '' ('': not mapped postfixes are discarded)
 
 
 DICOM:

--- a/bidscoin/heuristics/bidsmap_sst.yaml
+++ b/bidscoin/heuristics/bidsmap_sst.yaml
@@ -35,6 +35,7 @@ Options:
       args: -b y -z y -i n -l n     # Argument string that is passed to dcm2niix. Tip: SPM users may want to use '-z n' (which produces unzipped NIfTI's, see dcm2niix -h for more information)
       anon: y                       # Set this anonymization flag to 'y' to round off age and discard acquisition date from the meta data
       meta: [.json, .tsv, .tsv.gz]  # The file extensions of the equally named metadata sourcefiles that are copied over to the BIDS sidecar files
+      fallback: 'acq'               # Fallback BIDS label for not mapped dcm2niix postfixes, allowed values are 'acq' or '' ('': not mapped postfixes are discarded)
 
 
 DICOM:

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -404,9 +404,10 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                         newbidsname = newbidsname.replace('_magnitude_ph',   '_fieldmap')                       # Case 3: One magnitude + one fieldmap image in one folder / datasource
                         newbidsname = newbidsname.replace('_fieldmap_ph',    '_fieldmap')                       # Case 3
 
-                    # Append the dcm2niix info to acq-label, may need to be improved / elaborated for future BIDS standards, supporting multi-coil data
+                    # Append the dcm2niix info to acq-label if it is not defined, may need to be improved / elaborated for future BIDS standards, supporting multi-coil data
                     else:
-                        newbidsname = bids.get_bidsvalue(newbidsname, 'dummy', postfix)
+                        if not bids.get_bidsvalue(dcm2niixfile.name, 'acq'):
+                            newbidsname = bids.get_bidsvalue(newbidsname, 'dummy', postfix)
 
                     # Remove the added postfix from the new bidsname
                     newbidsname = newbidsname.replace(f"_{postfix}_",'_')                                       # If it is not last

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -404,10 +404,9 @@ def bidscoiner_plugin(session: Path, bidsmap: dict, bidsses: Path) -> Union[None
                         newbidsname = newbidsname.replace('_magnitude_ph',   '_fieldmap')                       # Case 3: One magnitude + one fieldmap image in one folder / datasource
                         newbidsname = newbidsname.replace('_fieldmap_ph',    '_fieldmap')                       # Case 3
 
-                    # Append the dcm2niix info to acq-label if it is not defined, may need to be improved / elaborated for future BIDS standards, supporting multi-coil data
+                    # Append the dcm2niix info to acq-label, may need to be improved / elaborated for future BIDS standards, supporting multi-coil data
                     else:
-                        if not bids.get_bidsvalue(dcm2niixfile.name, 'acq'):
-                            newbidsname = bids.get_bidsvalue(newbidsname, 'dummy', postfix)
+                        newbidsname = bids.get_bidsvalue(newbidsname, 'dummy', postfix)
 
                     # Remove the added postfix from the new bidsname
                     newbidsname = newbidsname.replace(f"_{postfix}_",'_')                                       # If it is not last

--- a/tests/test_data/bidsmap.yaml
+++ b/tests/test_data/bidsmap.yaml
@@ -33,6 +33,7 @@ Options:
       args: -b y -z y -i n -l n     # Argument string that is passed to dcm2niix. Tip: SPM users may want to use '-z n' (which produces unzipped nifti's, see dcm2niix -h for more information)
       anon: y                       # Set this anonymization flag to 'y' to round off age and discard acquisition date from the meta data
       meta: [.json, .tsv, .tsv.gz]  # The file extensions of the equally named metadata sourcefiles that are copied over to the BIDS sidecar files
+      fallback: 'acq'               # Fallback BIDS label for not mapped dcm2niix postfixes, allowed values are 'acq' or '' ('': not mapped postfixes are discarded)
     spec2nii2bids:                  # The settings for the spec2nii2bids plugin
       command: spec2nii             # Command to run spec2nii, e.g. "module add spec2nii; spec2nii" or "PATH=/opt/spec2nii/bin:$PATH; spec2nii" or /opt/spec2nii/bin/spec2nii or 'C:\"Program Files"\spec2nii\spec2nii.exe' (note the quotes to deal with the whitespace)
       args:                         # Argument string that is passed to spec2nii (see spec2nii -h for more information)


### PR DESCRIPTION
I suggest not appending to acq label dcm2niix postfix if user has defined the acq label in bidsmap, since that is the acq label user needs.