### PR TITLE
Update targets if run-1 added in increment_runindex within dcm2niixfiles loop

### DIFF
--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -2003,8 +2003,9 @@ def increment_runindex(outfolder: Path, bidsname: str, run: Run) -> str:
             LOGGER.verbose(f"Found run-2 files for <<>> index, renaming\n{runless_file} -> {run1_name}")
             run1_file = (outfolder/run1_name).with_suffix(''.join(runless_file.suffixes))
             runless_file.replace(run1_file)
-            targets.discard(runless_file)
-            targets.add(run1_file)
+            if runless_file in targets:
+                targets.remove(runless_file)
+                targets.add(run1_file)
 
     return bidsname + bidsext
 

--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -1954,17 +1954,18 @@ def insert_bidskeyval(bidsfile: Union[str, Path], bidskey: str, newvalue: str, v
     return newbidsfile
 
 
-def increment_runindex(outfolder: Path, bidsname: str, run: Run) -> str:
+def increment_runindex(outfolder: Path, bidsname: str, run: Run, targets: set=()) -> str:
     """
     Checks if a file with the same bidsname already exists in the folder and then increments the dynamic runindex
     (if any) until no such file is found.
 
     NB: For <<>> runs, if the run-less file already exists, then add 'run-2' to bidsname and rename run-less files
-    to 'run-1'
+    and targets (optional) to 'run-1'
 
     :param outfolder:   The full pathname of the bids output folder
     :param bidsname:    The bidsname with a provisional runindex, e.g. from get_bidsname()
     :param run:         The run mapping with the BIDS key-value pairs
+    :param targets:     The set of output targets that need to remain in sync when renaming a run-less file
     :return:            The bidsname with the original or incremented runindex
     """
 

--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -2001,7 +2001,11 @@ def increment_runindex(outfolder: Path, bidsname: str, run: Run) -> str:
         # Rename run-less to run-1
         for runless_file in runless_files:
             LOGGER.verbose(f"Found run-2 files for <<>> index, renaming\n{runless_file} -> {run1_name}")
-            runless_file.replace((outfolder/run1_name).with_suffix(''.join(runless_file.suffixes)))
+            run1_file = (outfolder/run1_name).with_suffix(''.join(runless_file.suffixes))
+            runless_file.replace(run1_file)
+            if runless_file in targets:
+                targets.remove(runless_file)
+                targets.add(run1_file)
 
     return bidsname + bidsext
 

--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -2004,7 +2004,7 @@ def increment_runindex(outfolder: Path, bidsname: str, run: Run, targets: set=()
             LOGGER.verbose(f"Found run-2 files for <<>> index, renaming\n{runless_file} -> {run1_name}")
             run1_file = (outfolder/run1_name).with_suffix(''.join(runless_file.suffixes))
             runless_file.replace(run1_file)
-            if runless_file in targets:
+            if isinstance(targets, set):
                 targets.remove(runless_file)
                 targets.add(run1_file)
 

--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -2003,9 +2003,8 @@ def increment_runindex(outfolder: Path, bidsname: str, run: Run) -> str:
             LOGGER.verbose(f"Found run-2 files for <<>> index, renaming\n{runless_file} -> {run1_name}")
             run1_file = (outfolder/run1_name).with_suffix(''.join(runless_file.suffixes))
             runless_file.replace(run1_file)
-            if runless_file in targets:
-                targets.remove(runless_file)
-                targets.add(run1_file)
+            targets.discard(runless_file)
+            targets.add(run1_file)
 
     return bidsname + bidsext
 

--- a/bidscoin/bids.py
+++ b/bidscoin/bids.py
@@ -2004,7 +2004,7 @@ def increment_runindex(outfolder: Path, bidsname: str, run: Run, targets: set=()
             LOGGER.verbose(f"Found run-2 files for <<>> index, renaming\n{runless_file} -> {run1_name}")
             run1_file = (outfolder/run1_name).with_suffix(''.join(runless_file.suffixes))
             runless_file.replace(run1_file)
-            if isinstance(targets, set):
+            if runless_file in targets:
                 targets.remove(runless_file)
                 targets.add(run1_file)
 

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -454,6 +454,13 @@ def bidscoiner_plugin(session: Path, bidsmap: Bidsmap, bidsses: Path) -> Union[N
                     LOGGER.warning(f"Overwriting existing {newbidsfile} file -- check your results carefully!")
                 dcm2niixfile.replace(newbidsfile)
                 targets.add(newbidsfile)
+                if bids.get_bidsvalue(newbidsfile, 'run') == '2' and str(run['bids'].get('run') or '') == "<<>>":
+                    # run-less file could be changed in the last call of increment_runindex within dcm2niixfiles loop
+                    runless_bidsfile = bids.insert_bidskeyval(newbidsfile, 'run', '', False)
+                    run1_bidsfile = bids.insert_bidskeyval(newbidsfile, 'run', '1', False)
+                    if runless_bidsfile in targets and not runless_bidsfile.is_file() and run1_bidsfile.is_file():
+                        targets.remove(runless_bidsfile)
+                        targets.add(run1_bidsfile)
 
                 # Rename all associated files (i.e. the json-, bval- and bvec-files)
                 for oldfile in outfolder.glob(dcm2niixfile.with_suffix('').stem + '.*'):

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -447,7 +447,7 @@ def bidscoiner_plugin(session: Path, bidsmap: Bidsmap, bidsses: Path) -> Union[N
                         LOGGER.warning(f"The {newbidsname} image is a derivate / not BIDS-compliant -- you can probably delete it safely and update {scans_tsv}")
 
                 # Save the NIfTI file with the newly constructed name
-                newbidsname = bids.increment_runindex(outfolder, newbidsname, run)                              # Update the runindex now that the name has changed
+                newbidsname = bids.increment_runindex(outfolder, newbidsname, run, targets)                     # Update the runindex now that the name has changed
                 newbidsfile = outfolder/newbidsname
                 LOGGER.verbose(f"Found dcm2niix {postfixes} postfixes, renaming\n{dcm2niixfile} ->\n{newbidsfile}")
                 if newbidsfile.is_file():

--- a/bidscoin/plugins/dcm2niix2bids.py
+++ b/bidscoin/plugins/dcm2niix2bids.py
@@ -454,13 +454,6 @@ def bidscoiner_plugin(session: Path, bidsmap: Bidsmap, bidsses: Path) -> Union[N
                     LOGGER.warning(f"Overwriting existing {newbidsfile} file -- check your results carefully!")
                 dcm2niixfile.replace(newbidsfile)
                 targets.add(newbidsfile)
-                if bids.get_bidsvalue(newbidsfile, 'run') == '2' and str(run['bids'].get('run') or '') == "<<>>":
-                    # run-less file could be changed in the last call of increment_runindex within dcm2niixfiles loop
-                    runless_bidsfile = bids.insert_bidskeyval(newbidsfile, 'run', '', False)
-                    run1_bidsfile = bids.insert_bidskeyval(newbidsfile, 'run', '1', False)
-                    if runless_bidsfile in targets and not runless_bidsfile.is_file() and run1_bidsfile.is_file():
-                        targets.remove(runless_bidsfile)
-                        targets.add(run1_bidsfile)
 
                 # Rename all associated files (i.e. the json-, bval- and bvec-files)
                 for oldfile in outfolder.glob(dcm2niixfile.with_suffix('').stem + '.*'):


### PR DESCRIPTION
It can happen that `run_2` is added within dcm2niixfiles loop in `dcm2niix2bids.py` when dealing with postfixes.
Function `increment_runindex` renames runless file to run1 file but targets in dcm2niix2bids are not updated, and file stays runless.

